### PR TITLE
Handle data fetching 500 errors

### DIFF
--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,31 @@
+-- Migration script to fix database schema issues
+-- Run this if your database was created with the old schema
+
+-- Fix the criteria table: rename max_score to weight if it exists
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'criteria' AND column_name = 'max_score') THEN
+        ALTER TABLE criteria RENAME COLUMN max_score TO weight;
+    END IF;
+END$$;
+
+-- Fix the app_state table: replace active_team_id with active_team_ids array
+DO $$
+BEGIN
+    -- Check if old column exists
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'app_state' AND column_name = 'active_team_id') THEN
+        -- Add new column
+        ALTER TABLE app_state ADD COLUMN active_team_ids UUID[] DEFAULT ARRAY[]::UUID[];
+        
+        -- Migrate data if there was an active team
+        UPDATE app_state SET active_team_ids = ARRAY[active_team_id] WHERE active_team_id IS NOT NULL;
+        
+        -- Drop old column
+        ALTER TABLE app_state DROP COLUMN active_team_id;
+    END IF;
+    
+    -- Ensure the column exists even if the table was created differently
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'app_state' AND column_name = 'active_team_ids') THEN
+        ALTER TABLE app_state ADD COLUMN active_team_ids UUID[] DEFAULT ARRAY[]::UUID[];
+    END IF;
+END$$;

--- a/services/database.ts
+++ b/services/database.ts
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS judges (
 CREATE TABLE IF NOT EXISTS criteria (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   name VARCHAR(255) NOT NULL,
-  max_score INTEGER NOT NULL,
+  weight INTEGER NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -39,17 +39,17 @@ CREATE TABLE IF NOT EXISTS ratings (
   UNIQUE(judge_id, team_id)
 );
 
--- Table for general application state (like setup lock and active team)
+-- Table for general application state (like setup lock and active teams)
 -- This table will only ever have one row.
 CREATE TABLE IF NOT EXISTS app_state (
   id INT PRIMARY KEY DEFAULT 1,
   is_setup_locked BOOLEAN NOT NULL DEFAULT FALSE,
-  active_team_id UUID REFERENCES teams(id) ON DELETE SET NULL,
+  active_team_ids UUID[] DEFAULT ARRAY[]::UUID[],
   CONSTRAINT single_row CHECK (id = 1)
 );
 
 -- Insert the initial single row for app_state
-INSERT INTO app_state (id, is_setup_locked, active_team_id)
-VALUES (1, FALSE, NULL)
+INSERT INTO app_state (id, is_setup_locked, active_team_ids)
+VALUES (1, FALSE, ARRAY[]::UUID[])
 ON CONFLICT (id) DO NOTHING;
 `;


### PR DESCRIPTION
Correct database schema for `active_team_ids` and `weight` to resolve 500 errors in data API endpoints and provide a migration script.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb586b63-32cb-4416-bb8e-f4e908f642c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb586b63-32cb-4416-bb8e-f4e908f642c8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

