### PR TITLE
Handle data fetching 500 errors

### DIFF
--- a/DATABASE_FIX.md
+++ b/DATABASE_FIX.md
@@ -1,0 +1,47 @@
+# Database Schema Fix for 500 Errors
+
+## Issue Summary
+The application was experiencing 500 errors on two API endpoints:
+- `/api/data?entity=activeTeamIds:1`
+- `/api/data?entity=finalScores:1`
+
+## Root Causes
+
+### 1. activeTeamIds Endpoint
+- **Issue**: The API code was trying to query `active_team_ids` (plural, array) but the database schema had `active_team_id` (singular, UUID)
+- **Impact**: SQL query failed causing 500 error
+
+### 2. finalScores Endpoint
+- **Issue**: The API code expected a `weight` column in the `criteria` table, but the schema had `max_score` instead
+- **Impact**: Calculation failed when trying to access non-existent weight values
+
+## Solution
+
+### Step 1: Run Database Migration
+Execute the migration script in `migration.sql` on your Vercel Postgres database:
+
+```sql
+-- This will:
+-- 1. Add active_team_ids column (array) to app_state table
+-- 2. Migrate data from old active_team_id column
+-- 3. Add weight column to criteria table
+-- 4. Remove max_score column from criteria table
+```
+
+### Step 2: For Fresh Installations
+If setting up a new database, use the updated `schema.sql` file which includes:
+- `active_team_ids UUID[]` in app_state table
+- `weight NUMERIC(5,2)` in criteria table
+
+### Step 3: Verify the Fix
+After applying the migration:
+1. The `/api/data?entity=activeTeamIds` endpoint should return an array (possibly empty)
+2. The `/api/data?entity=finalScores` endpoint should return calculated scores with rankings
+
+## Files Updated
+- `services/database.ts` - Updated schema definition
+- `schema.sql` - Complete updated schema for new installations
+- `migration.sql` - Migration script for existing databases
+
+## Note
+The API code in `api/data.ts` was already correct and expecting the proper schema. The issue was a mismatch between the code expectations and the actual database schema.

--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,24 @@
+-- Migration to update app_state table to support multiple active teams
+
+-- Step 1: Add the new column for multiple active teams
+ALTER TABLE app_state 
+ADD COLUMN IF NOT EXISTS active_team_ids UUID[] DEFAULT '{}';
+
+-- Step 2: Migrate existing data from active_team_id to active_team_ids
+UPDATE app_state 
+SET active_team_ids = CASE 
+    WHEN active_team_id IS NOT NULL THEN ARRAY[active_team_id]
+    ELSE '{}'
+END
+WHERE id = 1;
+
+-- Step 3: Drop the old column (optional - only do this after confirming the migration worked)
+-- ALTER TABLE app_state DROP COLUMN active_team_id;
+
+-- Step 4: Update criteria table to include weight column if it doesn't exist
+ALTER TABLE criteria 
+ADD COLUMN IF NOT EXISTS weight NUMERIC(5,2) DEFAULT 1.0;
+
+-- Remove max_score column if it exists (since the code expects weight instead)
+ALTER TABLE criteria 
+DROP COLUMN IF EXISTS max_score;

--- a/schema.sql
+++ b/schema.sql
@@ -1,1 +1,53 @@
-ûäáŠË®*mr‰íj)ì¶’@·(šf§vËh±ën¦Ø^u«Zm«±È^™ø*)É©Ý¥«-zØ^z{b­ç(ž×§¶)í¢Ø^UêÜzSè²Ø+zÄ.z¼
+-- This script contains the SQL commands to set up the database schema.
+-- Copy and paste the entire content into the Vercel Postgres Query editor and run it once.
+
+-- Enable UUID generation
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Table for Teams
+CREATE TABLE IF NOT EXISTS teams (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Table for Judges
+CREATE TABLE IF NOT EXISTS judges (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name VARCHAR(255) NOT NULL,
+  secret_id VARCHAR(255) NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Table for Scoring Criteria
+CREATE TABLE IF NOT EXISTS criteria (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  name VARCHAR(255) NOT NULL,
+  weight NUMERIC(5,2) NOT NULL DEFAULT 1.0,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Table for Ratings
+-- Each judge can only rate each team once.
+CREATE TABLE IF NOT EXISTS ratings (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  judge_id UUID NOT NULL REFERENCES judges(id) ON DELETE CASCADE,
+  team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+  scores JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE(judge_id, team_id)
+);
+
+-- Table for general application state (like setup lock and active teams)
+-- This table will only ever have one row.
+CREATE TABLE IF NOT EXISTS app_state (
+  id INT PRIMARY KEY DEFAULT 1,
+  is_setup_locked BOOLEAN NOT NULL DEFAULT FALSE,
+  active_team_ids UUID[] DEFAULT '{}',
+  CONSTRAINT single_row CHECK (id = 1)
+);
+
+-- Insert the initial single row for app_state
+INSERT INTO app_state (id, is_setup_locked, active_team_ids)
+VALUES (1, FALSE, '{}')
+ON CONFLICT (id) DO NOTHING;

--- a/services/database.ts
+++ b/services/database.ts
@@ -24,7 +24,7 @@ CREATE TABLE IF NOT EXISTS judges (
 CREATE TABLE IF NOT EXISTS criteria (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   name VARCHAR(255) NOT NULL,
-  max_score INTEGER NOT NULL,
+  weight NUMERIC(5,2) NOT NULL DEFAULT 1.0,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
@@ -39,17 +39,17 @@ CREATE TABLE IF NOT EXISTS ratings (
   UNIQUE(judge_id, team_id)
 );
 
--- Table for general application state (like setup lock and active team)
+-- Table for general application state (like setup lock and active teams)
 -- This table will only ever have one row.
 CREATE TABLE IF NOT EXISTS app_state (
   id INT PRIMARY KEY DEFAULT 1,
   is_setup_locked BOOLEAN NOT NULL DEFAULT FALSE,
-  active_team_id UUID REFERENCES teams(id) ON DELETE SET NULL,
+  active_team_ids UUID[] DEFAULT '{}',
   CONSTRAINT single_row CHECK (id = 1)
 );
 
 -- Insert the initial single row for app_state
-INSERT INTO app_state (id, is_setup_locked, active_team_id)
-VALUES (1, FALSE, NULL)
+INSERT INTO app_state (id, is_setup_locked, active_team_ids)
+VALUES (1, FALSE, '{}')
 ON CONFLICT (id) DO NOTHING;
 `;


### PR DESCRIPTION
Fix 500 errors on `/api/data` endpoints by correcting database schema mismatches.

The `activeTeamIds` endpoint failed because the database schema had `active_team_id` (singular UUID) while the API expected `active_team_ids` (array of UUIDs). The `finalScores` endpoint failed because the `criteria` table had `max_score` instead of the `weight` column expected by the API. This PR updates the schema definitions and provides a migration script to align the database with the application's expectations.

---
<a href="https://cursor.com/background-agent?bcId=bc-513afb64-1ef2-4de5-8821-5bafaed72d5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-513afb64-1ef2-4de5-8821-5bafaed72d5e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

